### PR TITLE
feat: Merkle Proof RPC Service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Forge script config.
 PRIVATE_KEY=
 ETHEREUM_RPC_URL=
+ETHEREUM_WS=
 ETHERSCAN_API_KEY=
 
 # Avail circuit config.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "const-hex",
  "enr",
  "ethers-core",
+ "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -4485,6 +4486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rs_merkle"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05225752ca6ede4cb1b73aa37ce3904affd042e98f28246f56f438ebfd47a810"
+dependencies = [
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "ruint"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6530,6 +6540,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "redis",
  "reqwest",
+ "rs_merkle",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ path = "bin/genesis.rs"
 name = "indexer"
 path = "bin/indexer.rs"
 
+[[bin]]
+name = "events"
+path = "bin/events.rs"
+
 [features]
 ci = []
 
@@ -46,7 +50,7 @@ serde_json = "1.0.86"
 tokio = { version = "1.2.0", features = ["full"] }
 async-trait = "0.1.73"
 reqwest = "0.11.20"
-ethers = "2.0.10"
+ethers = { version = "2.0.10", features = ["ws"] }
 sha256 = "1.4.0"
 primitive-types = "0.12.1"
 
@@ -56,19 +60,20 @@ redis = { version = "0.23.3", features = [
     "tokio-comp",
 ] }
 
+dotenv = "0.15.0"
 avail-subxt = { git = "https://github.com/availproject/avail.git", rev = "df16508" }
+sha2 = { version = "0.10.8", default-features = false }
 sp-core = { version = "21.0.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = [
     "derive",
     "full",
     "bit-vec",
 ] }
-sha2 = "0.10.8"
-dotenv = "0.15.0"
 alloy-sol-types = "0.4.2"
 alloy-primitives = "0.4.2"
 subxt = "0.29"
 anyhow = "1.0.68"
 clap = "4.4.9"
+rs_merkle = "1.4.1"
 [dev-dependencies]
 anyhow = "1.0.68"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ roots from Avail blocks.
 ## Deployment
 The circuits are available on Succinct X [here](https://platform.succinct.xyz/succinctlabs/vectorx).
 
-Vector X is currently deployed for Avail's Goldberg testnet on Goerli [here](https://goerli.etherscan.io/address/0xc862F17Ebb256679D8b428634B8D1E5D8d9EBf67#events).
+Vector X is currently deployed for Avail's Goldberg testnet on Holesky [here](https://holesky.etherscan.io/address/0x17156d52c0707cde305661ba45457afc23d851e0#events).
 
 ## Integrate
 Get the genesis parameters for the `VectorX` contract with a specific Avail block (with no input defaults to block 1).

--- a/bin/events.rs
+++ b/bin/events.rs
@@ -94,7 +94,6 @@ async fn main() {
 
     let client = Arc::new(client);
 
-    // TODO: Change to HeaderRangeCommitmentStoredFilter type.
     let header_range_filter = Filter::new()
         .address(address)
         .event("HeaderRangeCommitmentStored(uint32,uint32,bytes32,bytes32)");

--- a/bin/events.rs
+++ b/bin/events.rs
@@ -45,7 +45,7 @@ async fn add_merkle_tree(
 
     let merkle_tree = MerkleTree::<Sha256>::from_leaves(&data_hashes);
     let root = merkle_tree.root().unwrap();
-    // assert_eq!(root.to_vec(), expected_data_commitment);
+    assert_eq!(root.to_vec(), expected_data_commitment);
     println!("root: {:?}", root);
 
     for i in 0..(end - start) {
@@ -121,6 +121,4 @@ async fn main() {
         )
         .await;
     }
-    // dotenv::dotenv().ok();
-    // add_merkle_tree(1, 2, vec![0u8; 32], 4).await;
 }

--- a/bin/events.rs
+++ b/bin/events.rs
@@ -79,7 +79,7 @@ async fn main() {
 
     let client = Arc::new(client);
 
-    // TODO: Use Header range commitment stored ABI type
+    // TODO: Change to HeaderRangeCommitmentStoredFilter type.
     let header_range_filter = Filter::new()
         .address(address)
         .event("HeaderRangeCommitmentStored(uint32,uint32,bytes32,bytes32)");
@@ -87,7 +87,6 @@ async fn main() {
     let mut stream = client.subscribe_logs(&header_range_filter).await.unwrap();
     while let Some(log) = stream.next().await {
         let log_bytes = log.data;
-        // Parse abi encoded logBytes (uint32, uint32, bytes32, bytes32)
         let decoded = HeaderRangeCommitmentStoredTuple::abi_decode(&log_bytes.0, true).unwrap();
 
         let trusted_block = decoded.0;

--- a/bin/events.rs
+++ b/bin/events.rs
@@ -1,0 +1,126 @@
+use std::env;
+use std::sync::Arc;
+
+use alloy_sol_types::{sol, SolType};
+use ethers::contract::abigen;
+use ethers::core::types::{Address, BlockNumber, Filter};
+use ethers::providers::{Middleware, Provider, StreamExt, Ws};
+use rs_merkle::algorithms::Sha256;
+use rs_merkle::MerkleTree;
+use vectorx::input::types::MerkleTreeBranch;
+use vectorx::input::RpcDataFetcher;
+
+// Note: Update ABI when updating contract.
+abigen!(VectorX, "./abi/VectorX.abi.json",);
+
+type HeaderRangeCommitmentStoredTuple = sol! { tuple(uint32, uint32, bytes32, bytes32) };
+
+// fn next_power_of_two(n: usize) -> usize {
+//     let mut power = 1;
+//     while power < n {
+//         power *= 2;
+//     }
+//     power
+// }
+
+// Not inclusive of start, but inclusive of end.
+async fn add_merkle_tree(
+    start: u32,
+    end: u32,
+    expected_data_commitment: Vec<u8>,
+    tree_num_leaves: usize,
+) {
+    // Listen to logs
+    let mut data_fetcher = RpcDataFetcher::new().await;
+
+    // Get all data_hashes for the range
+    let mut data_hashes = Vec::new();
+    for i in start + 1..end + 1 {
+        let header = data_fetcher.get_header(i).await;
+        data_hashes.push(header.data_root().0);
+    }
+
+    // Pad data_hashes with empty leaves, to match SimpleMerkleTree.
+    data_hashes.resize(tree_num_leaves, [0u8; 32]);
+
+    let merkle_tree = MerkleTree::<Sha256>::from_leaves(&data_hashes);
+    let root = merkle_tree.root().unwrap();
+    // assert_eq!(root.to_vec(), expected_data_commitment);
+    println!("root: {:?}", root);
+
+    for i in 0..(end - start) {
+        let proof = merkle_tree.proof(&[i as usize]);
+        let proof_hashes = proof.proof_hashes();
+        let branch = MerkleTreeBranch {
+            // Starts at start + 1
+            block_number: start + i + 1,
+            branch: proof_hashes.to_vec(),
+            root: root.to_vec(),
+            leaf: data_hashes[i as usize].to_vec(),
+        };
+        data_fetcher
+            .redis_client
+            .add_merkle_tree_branch(branch)
+            .await;
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env::set_var("RUST_LOG", "info");
+    dotenv::dotenv().ok();
+    env_logger::init();
+
+    let ethereum_ws = env::var("ETHEREUM_WS").expect("ETHEREUM_WS must be set");
+
+    let contract_address = env::var("CONTRACT_ADDRESS").expect("CONTRACT_ADDRESS must be set");
+    let address = contract_address
+        .parse::<Address>()
+        .expect("invalid address");
+
+    let client = Provider::<Ws>::connect(ethereum_ws).await.unwrap();
+    let contract = VectorX::new(address.0, client.clone().into());
+
+    // Note: This should be a power of 2, and is the size of the merkle tree.
+    let step_range_max = contract.max_header_range().await.unwrap();
+
+    let client = Arc::new(client);
+
+    let last_block = client
+        .get_block(BlockNumber::Latest)
+        .await
+        .unwrap()
+        .unwrap()
+        .number
+        .unwrap();
+    println!("last_block: {last_block}");
+
+    // TODO: Use Header range commitment stored ABI type
+    let header_range_filter = Filter::new()
+        .address(address)
+        // TODO: Remove from_block
+        .from_block(last_block - 2000)
+        .event("HeaderRangeCommitmentStored(uint32,uint32,bytes32,bytes32)");
+
+    let mut stream = client.subscribe_logs(&header_range_filter).await.unwrap();
+    while let Some(log) = stream.next().await {
+        // println!("log: {:?}", log);
+        let log_bytes = log.data;
+        // Parse abi encoded logBytes (uint32, uint32, bytes32, bytes32)
+        let decoded = HeaderRangeCommitmentStoredTuple::abi_decode(&log_bytes.0, true).unwrap();
+
+        let start_block = decoded.0;
+        let end_block = decoded.1;
+        let expected_data_commitment = decoded.2.to_vec();
+
+        add_merkle_tree(
+            start_block,
+            end_block,
+            expected_data_commitment,
+            step_range_max as usize,
+        )
+        .await;
+    }
+    // dotenv::dotenv().ok();
+    // add_merkle_tree(1, 2, vec![0u8; 32], 4).await;
+}

--- a/circuits/input/mod.rs
+++ b/circuits/input/mod.rs
@@ -134,7 +134,6 @@ impl RedisClient {
     }
 
     /// Stores merkle tree branch data in Redis. Errors if setting the key fails.
-    /// TODO: Batch add merkle tree data to Redis
     pub async fn add_merkle_tree_branch(&mut self, branch: MerkleTreeBranch) {
         let mut con = match self.get_connection().await {
             Ok(con) => con,

--- a/circuits/input/mod.rs
+++ b/circuits/input/mod.rs
@@ -133,7 +133,8 @@ impl RedisClient {
             .expect("Failed to get keys")
     }
 
-    /// Stores justification data in Redis. Errors if setting the key fails.
+    /// Stores merkle tree branch data in Redis. Errors if setting the key fails.
+    /// TODO: Batch add merkle tree data to Redis
     pub async fn add_merkle_tree_branch(&mut self, branch: MerkleTreeBranch) {
         let mut con = match self.get_connection().await {
             Ok(con) => con,

--- a/circuits/input/types.rs
+++ b/circuits/input/types.rs
@@ -31,6 +31,15 @@ pub struct StoredJustificationData {
     pub num_authorities: usize,
 }
 
+// Stores the Merkle tree data for Avail data commitments.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MerkleTreeBranch {
+    pub block_number: u32,
+    pub branch: Vec<[u8; 32]>,
+    pub root: Vec<u8>,
+    pub leaf: Vec<u8>,
+}
+
 #[derive(Debug)]
 pub struct CircuitJustification {
     pub authority_set_id: u64,

--- a/circuits/input/types.rs
+++ b/circuits/input/types.rs
@@ -36,6 +36,9 @@ pub struct StoredJustificationData {
 pub struct MerkleTreeBranch {
     pub block_number: u32,
     pub branch: Vec<[u8; 32]>,
+    // If path_index is true (1), then the new hash_so_far is sha256(branch_node || hash_so_far)
+    // Otherwise, sha256(hash_so_far || branch_node)
+    pub path_indices: Vec<bool>,
     pub root: Vec<u8>,
     pub leaf: Vec<u8>,
 }

--- a/circuits/subchain_verification.rs
+++ b/circuits/subchain_verification.rs
@@ -75,9 +75,6 @@ impl<L: PlonkParameters<D>, const D: usize> SubChainVerifier<L, D> for CircuitBu
 
         debug!("verify_subchain - num_map_jobs: {}", num_map_jobs);
 
-        // TODO: This should start from 0. Otherwise, the genesis block won't be included. This will
-        // be resolved in a later PR. Additionally, "head" in the smart contract should refer to the
-        // last block of the range, not the next block after the range.
         let relative_block_nums =
             (1u32..(num_map_jobs as u32 * HEADERS_PER_MAP as u32) + 1).collect_vec();
 

--- a/circuits/subchain_verification.rs
+++ b/circuits/subchain_verification.rs
@@ -75,6 +75,9 @@ impl<L: PlonkParameters<D>, const D: usize> SubChainVerifier<L, D> for CircuitBu
 
         debug!("verify_subchain - num_map_jobs: {}", num_map_jobs);
 
+        // TODO: This should start from 0. Otherwise, the genesis block won't be included. This will
+        // be resolved in a later PR. Additionally, "head" in the smart contract should refer to the
+        // last block of the range, not the next block after the range.
         let relative_block_nums =
             (1u32..(num_map_jobs as u32 * HEADERS_PER_MAP as u32) + 1).collect_vec();
 


### PR DESCRIPTION
Listen for `HeaderRangeCommitmentStored` events on the `VectorX` smart contract on Holesky, and store the corresponding merkle proof data for each `dataRoot` in Redis.

Via Succinct's API, Avail users will be able to query for the `dataRoot` proofs of arbitrary blocks (if they are included in a valid data commitment posted to Ethereum).