### PR TITLE
feat: some gas optimizations

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -2,7 +2,11 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-solc_version = "0.8.17"
+solc_version = "0.8.24"
+evm_version = "cancun"
+via_ir = true
+optimizer = true
+optimizer_runs = 999999
 verbosity = 3
 fs_permissions = [{ access = "read-write", path = "./"}]
 


### PR DESCRIPTION
* pack `frozen` with the `gateway` variable
* move `constant` variable up to comply with style guidelines, make `private` to save some gas, making it public isn't that useful anyway because it will be visible in the code
* remove `frozen` `false` init to save gas on unnecessary `SSTORE`
* some reordering and minor spacing fixes