### PR TITLE
feat: simplify `rotate` inputs

### DIFF
--- a/abi/VectorX.abi.json
+++ b/abi/VectorX.abi.json
@@ -72,11 +72,6 @@
                 "name": "_currentAuthoritySetId",
                 "type": "uint64",
                 "internalType": "uint64"
-            },
-            {
-                "name": "_epochEndBlock",
-                "type": "uint32",
-                "internalType": "uint32"
             }
         ],
         "outputs": [],
@@ -379,11 +374,6 @@
         "name": "requestNextAuthoritySetId",
         "inputs": [
             {
-                "name": "_epochEndBlock",
-                "type": "uint32",
-                "internalType": "uint32"
-            },
-            {
                 "name": "_currentAuthoritySetId",
                 "type": "uint64",
                 "internalType": "uint64"
@@ -641,12 +631,6 @@
                 "type": "bytes32",
                 "indexed": false,
                 "internalType": "bytes32"
-            },
-            {
-                "name": "epochEndBlock",
-                "type": "uint64",
-                "indexed": false,
-                "internalType": "uint64"
             }
         ],
         "anonymous": false
@@ -779,12 +763,6 @@
                 "type": "bytes32",
                 "indexed": false,
                 "internalType": "bytes32"
-            },
-            {
-                "name": "epochEndBlock",
-                "type": "uint64",
-                "indexed": false,
-                "internalType": "uint64"
             }
         ],
         "anonymous": false
@@ -885,6 +863,11 @@
     {
         "type": "error",
         "name": "ContractFrozen",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NextAuthoritySetExists",
         "inputs": []
     },
     {

--- a/bin/vectorx.rs
+++ b/bin/vectorx.rs
@@ -183,10 +183,6 @@ impl VectorXOperator {
                 "Requesting next authority set id, which is {:?}.",
                 current_authority_set_id + 1
             );
-            // Get the last block justified by the current authority set id (also a rotate block).
-            let last_justified_block = data_fetcher
-                .last_justified_block(current_authority_set_id)
-                .await;
 
             // Request the next authority set id.
             match self

--- a/bin/vectorx.rs
+++ b/bin/vectorx.rs
@@ -20,7 +20,7 @@ pub struct VectorXConfig {
     chain_id: u32,
 }
 
-type NextAuthoritySetInputTuple = sol! { tuple(uint64, bytes32, uint32) };
+type NextAuthoritySetInputTuple = sol! { tuple(uint64, bytes32) };
 
 type HeaderRangeInputTuple = sol! { tuple(uint32, bytes32, uint64, bytes32, uint32) };
 
@@ -124,7 +124,6 @@ impl VectorXOperator {
     async fn request_next_authority_set_id(
         &mut self,
         current_authority_set_id: u64,
-        epoch_end_block: u32,
         rotate_function_id: B256,
     ) -> Result<String> {
         let client = self.get_succinct_client();
@@ -142,13 +141,11 @@ impl VectorXOperator {
         let input = NextAuthoritySetInputTuple::abi_encode_packed(&(
             current_authority_set_id,
             current_authority_set_hash,
-            epoch_end_block,
         ));
 
         // Note: Use vector_x because the calls are the same.
         let add_next_authority_set_id_call = vector_x::AddNextAuthoritySetIdCall {
             current_authority_set_id,
-            epoch_end_block,
         };
         let function_data = add_next_authority_set_id_call.encode();
 
@@ -195,7 +192,6 @@ impl VectorXOperator {
             match self
                 .request_next_authority_set_id(
                     current_authority_set_id,
-                    last_justified_block,
                     rotate_contract_data.rotate_function_id,
                 )
                 .await

--- a/circuits/builder/rotate.rs
+++ b/circuits/builder/rotate.rs
@@ -1,6 +1,5 @@
 use plonky2x::frontend::curta::ec::point::CompressedEdwardsYVariable;
 use plonky2x::frontend::uint::uint64::U64Variable;
-use plonky2x::frontend::vars::U32Variable;
 use plonky2x::prelude::{
     ArrayVariable, ByteVariable, Bytes32Variable, CircuitBuilder, Field, PlonkParameters, Variable,
 };
@@ -57,7 +56,6 @@ pub trait RotateMethods {
         const MAX_SUBARRAY_SIZE: usize,
     >(
         &mut self,
-        epoch_end_block_number: U32Variable,
         current_authority_set_id: U64Variable,
         current_authority_set_hash: Bytes32Variable,
         rotate: RotateVariable<MAX_HEADER_SIZE, MAX_AUTHORITY_SET_SIZE>,
@@ -235,7 +233,6 @@ impl<L: PlonkParameters<D>, const D: usize> RotateMethods for CircuitBuilder<L, 
         const MAX_SUBARRAY_SIZE: usize,
     >(
         &mut self,
-        epoch_end_block_number: U32Variable,
         current_authority_set_id: U64Variable,
         current_authority_set_hash: Bytes32Variable,
         rotate: RotateVariable<MAX_HEADER_SIZE, MAX_AUTHORITY_SET_SIZE>,
@@ -252,7 +249,7 @@ impl<L: PlonkParameters<D>, const D: usize> RotateMethods for CircuitBuilder<L, 
 
         // Verify the justification from the current authority set on the epoch end header.
         self.verify_simple_justification::<MAX_AUTHORITY_SET_SIZE>(
-            epoch_end_block_number,
+            rotate.epoch_end_block_number,
             target_header_hash,
             current_authority_set_id,
             current_authority_set_hash,

--- a/circuits/vars.rs
+++ b/circuits/vars.rs
@@ -48,6 +48,7 @@ pub struct JustificationVariable<const MAX_AUTHORITY_SET_SIZE: usize> {
 #[derive(Clone, Debug, CircuitVariable)]
 #[value_name(RotateStruct)]
 pub struct RotateVariable<const MAX_HEADER_SIZE: usize, const MAX_AUTHORITY_SET_SIZE: usize> {
+    pub epoch_end_block_number: U32Variable,
     pub target_header: EncodedHeaderVariable<MAX_HEADER_SIZE>,
     pub target_header_num_authorities: Variable,
     pub next_authority_set_start_position: Variable,

--- a/contracts/src/interfaces/IVectorX.sol
+++ b/contracts/src/interfaces/IVectorX.sol
@@ -19,11 +19,9 @@ interface IVectorX {
     /// @notice Emits event with the inputs of a next authority set id request.
     /// @param currentAuthoritySetId The authority set id of the current authority set.
     /// @param currentAuthoritySetHash The authority set hash of the current authority set.
-    /// @param epochEndBlock The height of the epoch end block.
     event NextAuthoritySetIdRequested(
         uint64 currentAuthoritySetId,
-        bytes32 currentAuthoritySetHash,
-        uint64 epochEndBlock
+        bytes32 currentAuthoritySetHash
     );
 
     /// @notice Emitted when the light client's head is updated.
@@ -38,11 +36,10 @@ interface IVectorX {
     );
 
     /// @notice Emitted when a new authority set is stored.
-    event AuthoritySetStored(
-        uint64 authoritySetId,
-        bytes32 authoritySetHash,
-        uint64 epochEndBlock
-    );
+    event AuthoritySetStored(uint64 authoritySetId, bytes32 authoritySetHash);
+
+    /// @notice If the next authority set already exists.
+    error NextAuthoritySetExists();
 
     /// @notice Contract is frozen.
     error ContractFrozen();


### PR DESCRIPTION
Epoch end block number is not a required input to `rotate` and is deterministic from the `authority_set_id`.