### PR TITLE
feat: gas optimizations

### DIFF
--- a/abi/VectorX.abi.json
+++ b/abi/VectorX.abi.json
@@ -27,19 +27,6 @@
     },
     {
         "type": "function",
-        "name": "MAX_HEADER_RANGE",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint32",
-                "internalType": "uint32"
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
         "name": "TIMELOCK_ROLE",
         "inputs": [],
         "outputs": [


### PR DESCRIPTION
- Pack frozen with the gateway variable
- Remove frozen false init to save gas on unnecessary SSTORE
- Some reordering and minor spacing fixes
- Remove `DATA_COMMITMENT_MAX` constant, as the circuit now enforces this constraint.

Thanks @QEDK for https://github.com/succinctlabs/vectorx/pull/132!

