### PR TITLE
fix(audit): track latest authority set used in `commitHeaderRange`

### DIFF
--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -269,42 +269,39 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
         latestBlock = _targetBlock;
     }
 
-    /// @notice Requests a rotate to a next authority set after the latest authority set in the contract.
-    /// @param _latestAuthoritySetId The authority set id of the latest authority set stored in the contract.
-    function requestRotate(uint64 _latestAuthoritySetId) external payable {
-        bytes32 latestAuthoritySetHash = authoritySetIdToHash[
-            _latestAuthoritySetId
+    /// @notice Requests a rotate to the next authority set.
+    /// @param _currentAuthoritySetId The authority set id of the current authority set.
+    function requestRotate(uint64 _currentAuthoritySetId) external payable {
+        bytes32 currentAuthoritySetHash = authoritySetIdToHash[
+            _currentAuthoritySetId
         ];
-        if (latestAuthoritySetHash == bytes32(0)) {
+        if (currentAuthoritySetHash == bytes32(0)) {
             revert AuthoritySetNotFound();
         }
 
-        bytes32 newAuthoritySetHash = authoritySetIdToHash[
-            _latestAuthoritySetId + 1
+        bytes32 nextAuthoritySetHash = authoritySetIdToHash[
+            _currentAuthoritySetId + 1
         ];
-        if (newAuthoritySetHash != bytes32(0)) {
+        if (nextAuthoritySetHash != bytes32(0)) {
             revert NextAuthoritySetExists();
         }
 
         bytes memory input = abi.encodePacked(
-            latestAuthoritySetHash,
-            _latestAuthoritySetId
+            _currentAuthoritySetId,
+            currentAuthoritySetHash
         );
 
         bytes memory data = abi.encodeWithSelector(
             this.rotate.selector,
-            _latestAuthoritySetId
+            _currentAuthoritySetId
         );
 
         ISuccinctGateway(gateway).requestCall{value: msg.value}(
-            rotateFunctionId,
-            input,
-            address(this),
-            data,
+	@@ -291,7 +304,7 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
             500000
         );
 
-        emit RotateRequested(_latestAuthoritySetId, latestAuthoritySetHash);
+        emit RotateRequested(_currentAuthoritySetId, currentAuthoritySetHash);
     }
 
     /// @notice Adds the authority set hash for the next authority set id.

--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -18,9 +18,8 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
     /// @notice The latest block that has been committed.
     uint32 public latestBlock;
 
-    /// @notice The current authority set id. When a header range is committed, the current authority set id
-    ///     is updated to the authority set id of the header range.
-    uint64 public currentAuthoritySetId;
+    /// @notice The latest authority set id used in commitHeaderRange.
+    uint64 public latestAuthoritySetId;
 
     /// @notice The function for requesting a header range.
     bytes32 public headerRangeFunctionId;
@@ -64,7 +63,7 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
 
         blockHeightToHeaderHash[_params.height] = _params.header;
         authoritySetIdToHash[_params.authoritySetId] = _params.authoritySetHash;
-        currentAuthoritySetId = _params.authoritySetId;
+        latestAuthoritySetId = _params.authoritySetId;
         latestBlock = _params.height;
 
         rotateFunctionId = _params.rotateFunctionId;
@@ -220,12 +219,12 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
             revert AuthoritySetNotFound();
         }
 
-        if (_authoritySetId < currentAuthoritySetId) {
+        if (_authoritySetId < latestAuthoritySetId) {
             revert OldAuthoritySetId();
         }
 
-        if (_authoritySetId > currentAuthoritySetId) {
-            currentAuthoritySetId = _authoritySetId;
+        if (_authoritySetId > latestAuthoritySetId) {
+            latestAuthoritySetId = _authoritySetId;
         }
 
         require(_targetBlock > latestBlock);

--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -309,6 +309,13 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
             revert AuthoritySetNotFound();
         }
 
+        bytes32 nextAuthoritySetHash = authoritySetIdToHash[
+            _currentAuthoritySetId + 1
+        ];
+        if (nextAuthoritySetHash != bytes32(0)) {
+            revert NextAuthoritySetExists();
+        }
+
         bytes memory input = abi.encodePacked(
             _currentAuthoritySetId,
             currentAuthoritySetHash

--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -296,7 +296,13 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
             _currentAuthoritySetId
         );
 
-        ISuccinctGateway(gateway).requestCall{value: msg.value}(500000);
+        ISuccinctGateway(gateway).requestCall{value: msg.value}(
+            rotateFunctionId,
+            input,
+            address(this),
+            data,
+            500000
+        );
 
         emit RotateRequested(_currentAuthoritySetId, currentAuthoritySetHash);
     }

--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -296,10 +296,7 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
             _currentAuthoritySetId
         );
 
-        ISuccinctGateway(gateway).requestCall{value: msg.value}(
-	@@ -291,7 +304,7 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
-            500000
-        );
+        ISuccinctGateway(gateway).requestCall{value: msg.value}(500000);
 
         emit RotateRequested(_currentAuthoritySetId, currentAuthoritySetHash);
     }

--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -99,8 +99,10 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
         bytes32 _authoritySetHash
     ) external onlyGuardian {
         blockHeightToHeaderHash[_height] = _header;
-        authoritySetIdToHash[_authoritySetId] = _authoritySetHash;
         latestBlock = _height;
+
+        authoritySetIdToHash[_authoritySetId] = _authoritySetHash;
+        latestAuthoritySetId = _authoritySetId;
     }
 
     /// @notice Force update the data & state commitments for a range of blocks.
@@ -140,8 +142,10 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
                 _stateRootCommitments[i]
             );
         }
-        authoritySetIdToHash[_endAuthoritySetId] = _endAuthoritySetHash;
         latestBlock = _endBlocks[_endBlocks.length - 1];
+
+        authoritySetIdToHash[_endAuthoritySetId] = _endAuthoritySetHash;
+        latestAuthoritySetId = _endAuthoritySetId;
     }
 
     /// @notice Request a header update and data commitment from range (latestBlock, requestedBlock].

--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -322,13 +322,6 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
             revert AuthoritySetNotFound();
         }
 
-        bytes32 nextAuthoritySetHash = authoritySetIdToHash[
-            _currentAuthoritySetId + 1
-        ];
-        if (nextAuthoritySetHash != bytes32(0)) {
-            revert NextAuthoritySetExists();
-        }
-
         bytes memory input = abi.encodePacked(
             _currentAuthoritySetId,
             currentAuthoritySetHash

--- a/contracts/src/interfaces/IVectorX.sol
+++ b/contracts/src/interfaces/IVectorX.sol
@@ -49,4 +49,7 @@ interface IVectorX {
 
     /// @notice Authority set not found.
     error AuthoritySetNotFound();
+
+    /// @notice The authority set id is older than the authority set id of the latest commitHeaderRange.
+    error OldAuthoritySetId();
 }


### PR DESCRIPTION
Store the latest authorization id used in `commitHeaderRange`, and check that any new `commitHeaderRange` call has an authority set id >= the most recently used authority set id.