### PR TITLE
fix(audit): Add `cargo audit` to CI, update `ed25519_dalek`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
           toolchain: nightly-2024-02-22
           override: true
 
+      - name: Run cargo audit
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,8 +1650,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "ed25519 1.5.3",
- "rand 0.7.3",
- "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -7314,7 +7312,7 @@ dependencies = [
  "avail-subxt",
  "clap 4.5.2",
  "dotenv",
- "ed25519-dalek 1.0.1",
+ "ed25519-dalek 2.1.1",
  "env_logger 0.9.3",
  "ethers",
  "ff_ce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ ci = []
 
 [dependencies]
 env_logger = { version = "0.9.0", default-features = false }
-ed25519-dalek = "1.0.1"
 hex = "0.4.3"
 itertools = "0.10.5"
 ff = { package = "ff_ce", version = "0.11", features = ["derive"] }
@@ -87,6 +86,7 @@ clap = "4.4.9"
 rs_merkle = "1.4.1"
 futures = "0.3.30"
 async-trait = "0.1.77"
+ed25519-dalek = "2.1.1"
 [dev-dependencies]
 anyhow = "1.0.68"
 

--- a/circuits/input/mod.rs
+++ b/circuits/input/mod.rs
@@ -13,7 +13,7 @@ use avail_subxt::primitives::Header;
 use avail_subxt::subxt_rpc::RpcParams;
 use avail_subxt::{api, build_client};
 use codec::{Compact, Decode, Encode};
-use ed25519_dalek::{PublicKey, Signature, Verifier};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use ethers::types::H256;
 use futures::future::join_all;
 use log::{debug, info};
@@ -200,9 +200,9 @@ impl RedisClient {
 }
 
 /// This function is useful for verifying that a Ed25519 signature is valid, it will panic if the signature is not valid
-pub fn verify_signature(pubkey_bytes: &[u8], signed_message: &[u8], signature: &[u8; 64]) {
-    let pubkey_dalek = PublicKey::from_bytes(pubkey_bytes).unwrap();
-    let verified = pubkey_dalek.verify(signed_message, &Signature::from_bytes(signature).unwrap());
+pub fn verify_signature(pubkey_bytes: &[u8; 32], signed_message: &[u8], signature: &[u8; 64]) {
+    let pubkey = VerifyingKey::from_bytes(pubkey_bytes).unwrap();
+    let verified = pubkey.verify(signed_message, &Signature::from_bytes(signature));
     if verified.is_err() {
         panic!("Signature is not valid");
     }
@@ -689,7 +689,7 @@ impl RpcDataFetcher {
                 .for_each(|precommit| {
                     let pubkey = precommit.clone().id;
                     let signature = precommit.clone().signature.0;
-                    let pubkey_bytes = pubkey.0.to_vec();
+                    let pubkey_bytes = pubkey.0;
 
                     // Verify the signature by this validator over the signed_message which is shared.
                     verify_signature(&pubkey_bytes, &signed_message, &signature);
@@ -701,7 +701,7 @@ impl RpcDataFetcher {
             let mut pubkeys = Vec::new();
             let mut voting_weight = 0;
             for pubkey_bytes in authorities_pubkey_bytes.iter() {
-                let signature = pubkey_bytes_to_signature.get(&pubkey_bytes.as_bytes().to_vec());
+                let signature = pubkey_bytes_to_signature.get(pubkey_bytes.as_bytes());
 
                 if let Some(valid_signature) = signature {
                     validator_signed.push(true);


### PR DESCRIPTION
The previous version of `ed25519_dalek` had a vulnerability. To detect this type of issue in the future, added `cargo audit` to CI.

Note: The https://github.com/succinctlabs/vectorx/pull/141 PR is necessary to remove all `ed25519_dalek` dependencies, as the version of `sp_io` used in this PR currently has the old version of `ed25519_dalek`. Once the audit fixes are merged, merging #141 will fix this issue.