### PR TITLE
fix(audit): check if authority hash already exists

### DIFF
--- a/contracts/src/VectorX.sol
+++ b/contracts/src/VectorX.sol
@@ -309,6 +309,13 @@ contract VectorX is IVectorX, TimelockedUpgradeable {
             revert AuthoritySetNotFound();
         }
 
+        bytes32 nextAuthoritySetHash = authoritySetIdToHash[
+            _currentAuthoritySetId + 1
+        ];
+        if (nextAuthoritySetHash != bytes32(0)) {
+            revert NextAuthoritySetExists();
+        }
+
         bytes memory input = abi.encodePacked(
             _currentAuthoritySetId,
             currentAuthoritySetHash


### PR DESCRIPTION
Revert if the authority hash already exists in the contract for `rotate`.